### PR TITLE
Fix UnicodeEncodeError when running the validator on Windows

### DIFF
--- a/docs/validate_graph.py
+++ b/docs/validate_graph.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 # Standard library
 import json
+import platform
 import sys
 import textwrap
 import warnings
@@ -2088,6 +2089,17 @@ def cli(input_args=None):
     int
         Process exit code (`0` if validation passes, `1` otherwise).
     """
+    # On Windows the default console encoding (e.g. cp1252) cannot render the
+    # status emojis used in the report, which raises a UnicodeEncodeError.
+    # Reconfigure the output streams to UTF-8 so the report prints correctly.
+    # (PYTHONIOENCODING cannot be used here because Python only reads it at
+    # interpreter startup, not when set from within the running script.)
+    if platform.system() == "Windows":
+        for stream in (sys.stdout, sys.stderr):
+            reconfigure = getattr(stream, "reconfigure", None)
+            if reconfigure is not None:
+                reconfigure(encoding="utf-8")
+
     parser = ArgumentParser(
         description="Validate on-disk neural-lam graph components and view the spec",  # noqa: E501
         formatter_class=ArgumentDefaultsHelpFormatter,


### PR DESCRIPTION
The validation report uses status emojis which the default Windows console encoding (cp1252) cannot render, raising a UnicodeEncodeError. Setting PYTHONIOENCODING from within the script does not help because Python only reads it at interpreter startup, so cli() reconfigures the output streams to UTF-8 directly on Windows.

## Describe your changes

Small follow-up to the Slack discussion on the graph-storage spec/validator.

The validation report prints status emojis (❌ / ⚠️ / ✅), which the default
Windows console encoding (cp1252) cannot render, so running the validator on
Windows raises a `UnicodeEncodeError`. `cli()` now reconfigures stdout/stderr to
UTF-8 on Windows before any output is printed.

Setting `PYTHONIOENCODING` from within the script does not work, because Python
only reads that variable at interpreter startup — by the time the script runs,
the streams are already created. Reconfiguring the streams directly
(`sys.stdout.reconfigure(encoding="utf-8")`) is what actually fixes it.

Verified manually on Windows: the report now prints correctly without needing
`PYTHONIOENCODING=utf-8`. It's a 12-line change (guarded `import platform` +
reconfigure block) and passes black/isort/flake8/mypy.

No new dependencies.

## Issue Link

N/A — follow-up to the spec/validator feedback discussed on Slack for #323.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📖 Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values <!-- N/A: no new functions, change is inside existing cli() -->
- [x] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code
- [ ] I have updated the [README](README.MD) to cover introduced code changes <!-- N/A -->
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- The fix is Windows-console-encoding-specific runtime behaviour and isn't practical to unit-test in CI; verified manually on Windows -->
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging). This applies only if you have write access to the repo, otherwise feel free to tag a maintainer to add a reviewer and assignee. <!-- No write access — tagging @leifdenby -->

## Checklist for reviewers

Each PR comes with its own improvements and flaws. The reviewer should check the following:
- [ ] the code is readable
- [ ] the code is well tested
- [ ] the code is documented (including return types and parameters)
- [ ] the code is easy to maintain

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section
  reflecting type of change (add section where missing):
  - *added*: when you have added new functionality
  - *changed*: when default behaviour of the code has been changed
  - *fixes*: when your contribution fixes a bug
  - *maintenance*: when your contribution is relates to repo maintenance, e.g. CI/CD or documentation

## Checklist for assignee

- [ ] PR is up to date with the base branch
- [ ] the tests pass
- [ ] (if the PR is not just maintenance/bugfix) the PR is assigned to the next milestone. If it is not, propose it for a future milestone.
- [ ] author has added an entry to the changelog (and designated the change as *added*, *changed*, *fixed* or *maintenance*)
